### PR TITLE
Added loading dependencies

### DIFF
--- a/lib/drone/models/payload_representer.rb
+++ b/lib/drone/models/payload_representer.rb
@@ -16,6 +16,11 @@
 
 require "representable/json"
 
+require_relative "build_representer"
+require_relative "repo_representer"
+require_relative "system_representer"
+require_relative "workspace_representer"
+
 module Drone
   #
   # Transform toplevel JSON payload

--- a/lib/drone/models/workspace_representer.rb
+++ b/lib/drone/models/workspace_representer.rb
@@ -16,6 +16,9 @@
 
 require "representable/json"
 
+require_relative "key_representer"
+require_relative "netrc_representer"
+
 module Drone
   #
   # Transform `workspace` JSON payload

--- a/lib/drone/plugin.rb
+++ b/lib/drone/plugin.rb
@@ -16,6 +16,9 @@
 
 require "json"
 
+require_relative "models/payload_representer"
+require_relative "models/payload"
+
 module Drone
   #
   # Plugin payload parser for Drone


### PR DESCRIPTION
This PR attempts to address random `uninitialized constant ` issues I ran into trying to use this gem such as:

```
/usr/lib/ruby/gems/2.2.0/gems/droneio-1.0.0/lib/drone/models/workspace_representer.rb:37:in `<class:WorkspaceRepresenter>': uninitialized constant Drone::WorkspaceRepresenter::NetrcRepresenter (NameError)
```